### PR TITLE
Convert to Node module; build with Browserify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+package-lock.json
+
 node_modules/
 bower_components/
 docs-out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-node_modules/,
-bower_components/,
-docs-out/,
-test/,
+node_modules/
+bower_components/
+docs-out/
+test/
 tests/
 TO_DO.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 package-lock.json
+dist/
+test/
 
 node_modules/
 bower_components/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ git:
 
 install: npm install
 
+before_script: npm run build
+
 script: npm test
 
 # End.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+
+language: node_js
+
+node_js: 8
+
+git:
+  depth: 8
+
+install: npm install
+
+script: npm test
+
+# End.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 language: node_js
 
-node_js: 8
+node_js: 8.1
 
 git:
   depth: 8

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-he MIT License (MIT)
+The MIT License (MIT)
 
 Copyright (c) 2016 Shivraj Rath
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sorts JSON object alphabetically. It supports nested objects, arrays and collect
 
 It converts this
 
-```javascript
+```json
 {
 	"object": {
 		"b": 2,
@@ -42,7 +42,7 @@ It converts this
 
 to this
 
-```javascript
+```json
 {
     "array": [
         "1",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ to this
 
 [JSON ABC][]
 
+---
+License: [MIT][]
+
 [json abc]: http://novicelab.org/jsonabc "JSON ABC online"
 [travis-icon]: https://travis-ci.org/nfreear/jsonabc.svg?branch=2.x
 [travis]: https://travis-ci.org/nfreear/jsonabc "Build status — Travis-CI"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-### JSON ABC
+
+[![Build Status][travis-icon]][travis]
+
+## JSON ABC
 
 Sorts JSON object alphabetically. It supports nested objects, arrays and collections. Works offline and beautifies JSON object too.
 
-#### Supports
+### Supports
 
 - Beautifies JSON
 - Sorts Plain Objects, Collections, Arrays
@@ -11,7 +14,7 @@ Sorts JSON object alphabetically. It supports nested objects, arrays and collect
 - Mobile/ Tablet friendly
 - Sorting plain arrays is optional
 
-#### Example
+### Example
 
 It converts this
 
@@ -81,4 +84,9 @@ to this
 }
 ```
 
-[JSON ABC](http://novicelab.org/jsonabc "JSON ABC")
+[JSON ABC][]
+
+[json abc]: http://novicelab.org/jsonabc "JSON ABC online"
+[travis-icon]: https://travis-ci.org/nfreear/jsonabc.svg?branch=2.x
+[travis]: https://travis-ci.org/nfreear/jsonabc "Build status — Travis-CI"
+[mit]: https://mit-license.org/2016?c=ShivrajRath

--- a/index.html
+++ b/index.html
@@ -38,14 +38,17 @@
             </a>
         </div>
     </div>
+
+    <form id="form" onsubmit="sort(event)">
+
     <div class="o mb10">
         <span>Options: &nbsp;&nbsp;</span>
         <input type="checkbox" id="noarray" name="noarray" value="true">
         <label for="noarray">Spare plain Arrays</label>
     </div>
     <div class="m">
-        <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here" spellcheck="false"></textarea>
-        <input type="button" class="f" value="SORT ABC" onclick="sort()">
+        <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here" spellcheck="false" required aria-required="true"></textarea>
+        <input type="submit" class="f" value="SORT ABC" data-onclick="sort()">
         <p>
             <h3 class="c">
                 <a href="https://twitter.com/shivrajrath" target="_blank">Twitter</a>&nbsp;&nbsp;&nbsp;
@@ -54,6 +57,8 @@
             </h3>
         </p>
     </div>
+
+    </form>
 
     <script src="index.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -15,115 +15,7 @@
     <meta name="msapplication-navbutton-color" content="#e6a117">
     <meta name="apple-mobile-web-app-status-bar-style" content="#e6a117">
     <title>JSON ABC - Sort JSON Alphabetically</title>
-    <style>
-        * {
-            margin: 0;
-            border: 0;
-            padding: 0;
-            vertical-align: baseline;
-            font-family: 'Palatino', 'Calibri', sans-serif;
-        }
-
-        html,
-        body {
-            height: 100%;
-            overflow: hidden;
-        }
-
-        body {
-            margin: 2% 5%;
-            line-height: 25px;
-        }
-
-        h2 {
-            color: #e6a117;
-        }
-
-        em {
-            font-weight: normal;
-        }
-
-        a {
-            color: #000;
-            text-decoration: none;
-            border-bottom: 1px solid #000;
-            padding-bottom: 3px;
-            cursor: pointer;
-        }
-
-        span>* {
-            display: inline-block;
-        }
-
-        .ad {
-            float: right;
-        }
-
-        .h {
-            font-size: 0.9em;
-            padding: 1% 0;
-        }
-
-        .m {
-            height: 65%;
-        }
-
-        .m .t,
-        .m .t:focus,
-        .m .t:active {
-            width: 95%;
-            height: 85%;
-            padding: 2%;
-            resize: none;
-            outline: none;
-            font-size: 1em;
-            text-decoration: none;
-            border: 1px solid #e6a117;
-            font-family: "Courier New", Courier, monospace;
-        }
-
-        .m .f {
-            font-size: 1em;
-            margin: 0 auto;
-            display: block;
-            cursor: pointer;
-            background: none;
-            padding: 1.5% 4% 1% 4%;
-            border: 1px solid #e6a117;
-        }
-
-        .b {
-            color: #e6a117;
-        }
-
-        .c {
-            text-align: center;
-            padding-top: 2%;
-        }
-
-        .mb10 {
-            margin-bottom: 10px;
-        }
-
-        @media only screen and (max-width: 768px) {
-            .ad {
-                display: none;
-            }
-            .m .t {
-                font-size: 0.5em;
-            }
-        }
-
-        @media only screen and (max-width: 420px) {
-            .ad {
-                display: none;
-
-            }
-            .m .t {
-                font-size: 0.3em;
-            }
-        }
-    </style>
+    <link href="style/app.css" rel="stylesheet">
 </head>
 
 <body>
@@ -137,48 +29,7 @@
 
         <div class="ad">
             <style>
-                .bmc-button img {
-                    width: 27px !important;
-                    margin-bottom: 3px !important;
-                    box-shadow: none !important;
-                    border: none !important;
-                    vertical-align: middle !important;
-                }
 
-                .bmc-button {
-                    line-height: 36px !important;
-                    height: 37px !important;
-                    text-decoration: none !important;
-                    display: inline-block !important;
-                    color: #FFFFFF !important;
-                    background-color: #FF813F !important;
-                    border-radius: 3px !important;
-                    border: 1px solid transparent !important;
-                    padding: 1px 9px !important;
-                    font-size: 23px !important;
-                    letter-spacing: 0.6px !important;
-                    box-shadow: 0px 1px 2px rgba(190, 190, 190, 0.5) !important;
-                    -webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
-                    margin: 0 auto !important;
-                    font-family: 'Cookie', cursive !important;
-                    -webkit-box-sizing: border-box !important;
-                    box-sizing: border-box !important;
-                    -o-transition: 0.3s all linear !important;
-                    -webkit-transition: 0.3s all linear !important;
-                    -moz-transition: 0.3s all linear !important;
-                    -ms-transition: 0.3s all linear !important;
-                    transition: 0.3s all linear !important;
-                }
-
-                .bmc-button:hover,
-                .bmc-button:active,
-                .bmc-button:focus {
-                    -webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
-                    text-decoration: none !important;
-                    box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
-                    opacity: 0.85 !important;
-                    color: #FFFFFF !important;
-                }
             </style>
             <link href="https://fonts.googleapis.com/css?family=Cookie" rel="stylesheet">
             <a class="bmc-button" target="_blank" href="https://www.buymeacoffee.com/rath">
@@ -197,94 +48,16 @@
         <input type="button" class="f" value="SORT ABC" onclick="sort()">
         <p>
             <h3 class="c">
-                <a href="http://twitter.com/shivrajrath" target="_blank">Twitter</a>&nbsp;&nbsp;&nbsp;
-                <a href="http://github.com/shivrajrath" target="_blank">Github</a>&nbsp;&nbsp;&nbsp;
+                <a href="https://twitter.com/shivrajrath" target="_blank">Twitter</a>&nbsp;&nbsp;&nbsp;
+                <a href="https://github.com/shivrajrath" target="_blank">Github</a>&nbsp;&nbsp;&nbsp;
                 <a href="http://novicelab.org" target="_blank">Blog</a>
             </h3>
         </p>
     </div>
-    <script>
-        // Is a value an array
-        function isArray(val) {
-            return Object.prototype.toString.call(val) === "[object Array]";
-        }
 
-        // Is a value an Object
-        function isPlainObject(val) {
-            return Object.prototype.toString.call(val) === "[object Object]";
-        }
+    <script src="index.js"></script>
 
-        // Sorting Logic
-        function sortJSON(un) {
-            var or = {};
-
-            if (isArray(un)) {
-                // Sort or don't sort arrays
-                if (document.getElementById('noarray').checked) {
-                    or = un;
-                } else {
-                    or = un.sort();
-                }
-
-                or.forEach(function (v, i) {
-                    or[i] = sortJSON(v)
-                });
-            } else if (isPlainObject(un)) {
-                or = {};
-                Object.keys(un).sort(function (a, b) {
-                    if (a.toLowerCase() < b.toLowerCase()) return -1;
-                    if (a.toLowerCase() > b.toLowerCase()) return 1;
-                    return 0;
-                }).forEach(function (key) {
-                    or[key] = sortJSON(un[key]);
-                });
-            } else {
-                or = un;
-            }
-
-            return or;
-        }
-
-        // Remove trailing commas
-        function cleanJSON(input) {
-            input = input.replace(/,[ \t\r\n]+}/g, '}');
-            input = input.replace(/,[ \t\r\n]+\]/g, ']');
-            return input;
-        }
-
-        // Sort the JSON
-        function sort() {
-            var input, j, r;
-
-            input = document.getElementById('t').value;
-            if (input) {
-                try {
-                    input = cleanJSON(input);
-                    j = JSON.parse(input);
-                    r = sortJSON(j);
-                    document.getElementById('t').value = JSON.stringify(r, null, 4);
-                } catch (ex) {
-                    alert('Incorrect JSON object');
-                }
-            }
-        }
-    </script>
-    <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r;
-            i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date();
-            a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0];
-            a.async = 1;
-            a.src = g;
-            m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-        ga('create', 'UA-58536835-1', 'auto');
-        ga('send', 'pageview');
-    </script>
+    <script src="src/app.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -28,9 +28,7 @@
         </span>
 
         <div class="ad">
-            <style>
-
-            </style>
+            <style> </style>
             <link href="https://fonts.googleapis.com/css?family=Cookie" rel="stylesheet">
             <a class="bmc-button" target="_blank" href="https://www.buymeacoffee.com/rath">
                 <img src="https://www.buymeacoffee.com/assets/img/BMC-btn-logo.svg" alt="Buy me a coffee">
@@ -39,7 +37,7 @@
         </div>
     </div>
 
-    <form id="form" onsubmit="appSort(event)">
+    <form onsubmit="appSort(event, 't')">
 
     <div class="o mb10">
         <span>Options: &nbsp;&nbsp;</span>
@@ -47,8 +45,9 @@
         <label for="noarray">Spare plain Arrays</label>
     </div>
     <div class="m">
-        <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here" spellcheck="false" required aria-required="true"></textarea>
-        <input type="submit" class="f" value="SORT ABC" data-onclick="sort()">
+        <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here"
+          aria-label="Paste your unsorted JSON here" spellcheck="false" required aria-required="true"></textarea>
+        <input type="submit" class="f" value="SORT ABC" data-Was-onclick="sort()">
         <p>
             <h3 class="c">
                 <a href="https://twitter.com/shivrajrath" target="_blank">Twitter</a>&nbsp;&nbsp;&nbsp;
@@ -60,7 +59,7 @@
 
     </form>
 
-    <script src="index.js"></script>
+    <script src="dist/jsonabc.js"></script>
 
     <script src="src/app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <form id="form" onsubmit="sort(event)">
+    <form id="form" onsubmit="appSort(event)">
 
     <div class="o mb10">
         <span>Options: &nbsp;&nbsp;</span>

--- a/index.js
+++ b/index.js
@@ -1,67 +1,72 @@
+/*! jsonabc Javascript.
+*/
+
+window.sort = sort;
 
 // Is a value an array
-function isArray(val) {
-    return Object.prototype.toString.call(val) === "[object Array]";
+function isArray (val) {
+  return Object.prototype.toString.call(val) === '[object Array]';
 }
 
 // Is a value an Object
-function isPlainObject(val) {
-    return Object.prototype.toString.call(val) === "[object Object]";
+function isPlainObject (val) {
+  return Object.prototype.toString.call(val) === '[object Object]';
 }
 
 // Sorting Logic
-function sortJSON(un) {
-    var or = {};
+function sortJSON (un) {
+  var or = {};
 
-    if (isArray(un)) {
-        // Sort or don't sort arrays
-        if (document.getElementById('noarray').checked) {
-            or = un;
-        } else {
-            or = un.sort();
-        }
-
-        or.forEach(function (v, i) {
-            or[i] = sortJSON(v)
-        });
-    } else if (isPlainObject(un)) {
-        or = {};
-        Object.keys(un).sort(function (a, b) {
-            if (a.toLowerCase() < b.toLowerCase()) return -1;
-            if (a.toLowerCase() > b.toLowerCase()) return 1;
-            return 0;
-        }).forEach(function (key) {
-            or[key] = sortJSON(un[key]);
-        });
+  if (isArray(un)) {
+    // Sort or don't sort arrays
+    if (document.getElementById('noarray').checked) {
+      or = un;
     } else {
-        or = un;
+      or = un.sort();
     }
 
-    return or;
+    or.forEach(function (v, i) {
+      or[i] = sortJSON(v);
+    });
+  } else if (isPlainObject(un)) {
+    or = {};
+    Object.keys(un).sort(function (a, b) {
+      if (a.toLowerCase() < b.toLowerCase()) return -1;
+      if (a.toLowerCase() > b.toLowerCase()) return 1;
+      return 0;
+    }).forEach(function (key) {
+      or[key] = sortJSON(un[key]);
+    });
+  } else {
+    or = un;
+  }
+
+  return or;
 }
 
 // Remove trailing commas
-function cleanJSON(input) {
-    input = input.replace(/,[ \t\r\n]+}/g, '}');
-    input = input.replace(/,[ \t\r\n]+\]/g, ']');
-    return input;
+function cleanJSON (input) {
+  input = input.replace(/,[ \t\r\n]+}/g, '}');
+  input = input.replace(/,[ \t\r\n]+\]/g, ']');
+  return input;
 }
 
 // Sort the JSON
-function sort() {
-    var input, j, r;
+function sort () {
+  var input, j, r;
 
-    input = document.getElementById('t').value;
-    if (input) {
-        try {
-            input = cleanJSON(input);
-            j = JSON.parse(input);
-            r = sortJSON(j);
-            document.getElementById('t').value = JSON.stringify(r, null, 4);
-        } catch (ex) {
-            alert('Incorrect JSON object');
-        }
+  input = document.getElementById('t').value;
+  if (input) {
+    try {
+      input = cleanJSON(input);
+      j = JSON.parse(input);
+      r = sortJSON(j);
+      document.getElementById('t').value = JSON.stringify(r, null, 4);
+    } catch (ex) {
+      console.error('Incorrect JSON object');
+      window.alert('Incorrect JSON object');
     }
+  }
 }
 
 // End.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,67 @@
+
+// Is a value an array
+function isArray(val) {
+    return Object.prototype.toString.call(val) === "[object Array]";
+}
+
+// Is a value an Object
+function isPlainObject(val) {
+    return Object.prototype.toString.call(val) === "[object Object]";
+}
+
+// Sorting Logic
+function sortJSON(un) {
+    var or = {};
+
+    if (isArray(un)) {
+        // Sort or don't sort arrays
+        if (document.getElementById('noarray').checked) {
+            or = un;
+        } else {
+            or = un.sort();
+        }
+
+        or.forEach(function (v, i) {
+            or[i] = sortJSON(v)
+        });
+    } else if (isPlainObject(un)) {
+        or = {};
+        Object.keys(un).sort(function (a, b) {
+            if (a.toLowerCase() < b.toLowerCase()) return -1;
+            if (a.toLowerCase() > b.toLowerCase()) return 1;
+            return 0;
+        }).forEach(function (key) {
+            or[key] = sortJSON(un[key]);
+        });
+    } else {
+        or = un;
+    }
+
+    return or;
+}
+
+// Remove trailing commas
+function cleanJSON(input) {
+    input = input.replace(/,[ \t\r\n]+}/g, '}');
+    input = input.replace(/,[ \t\r\n]+\]/g, ']');
+    return input;
+}
+
+// Sort the JSON
+function sort() {
+    var input, j, r;
+
+    input = document.getElementById('t').value;
+    if (input) {
+        try {
+            input = cleanJSON(input);
+            j = JSON.parse(input);
+            r = sortJSON(j);
+            document.getElementById('t').value = JSON.stringify(r, null, 4);
+        } catch (ex) {
+            alert('Incorrect JSON object');
+        }
+    }
+}
+
+// End.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-/*! JSON ABC Javascript.
+/*!
+  JSON ABC | License: MIT.
 */
 
 module.exports = {
@@ -7,12 +8,12 @@ module.exports = {
   cleanJSON: cleanJSON
 };
 
-// Is a value an array
+// Is a value an array?
 function isArray (val) {
   return Object.prototype.toString.call(val) === '[object Array]';
 }
 
-// Is a value an Object
+// Is a value an Object?
 function isPlainObject (val) {
   return Object.prototype.toString.call(val) === '[object Object]';
 }

--- a/index.js
+++ b/index.js
@@ -52,10 +52,13 @@ function cleanJSON (input) {
 }
 
 // Sort the JSON
-function sort () {
+function sort (ev) {
   var input, j, r;
 
   input = document.getElementById('t').value;
+
+  ev && ev.preventDefault();
+
   if (input) {
     try {
       input = cleanJSON(input);

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-/*! jsonabc Javascript.
+/*! JSON ABC Javascript.
 */
 
-window.sort = sort;
+// Start with a single exposed function.
+window.jsonabc = { sort: sort };
 
 // Is a value an array
 function isArray (val) {
@@ -14,12 +15,12 @@ function isPlainObject (val) {
 }
 
 // Sorting Logic
-function sortJSON (un) {
+function sortJSON (un, noarray) {
   var or = {};
 
   if (isArray(un)) {
     // Sort or don't sort arrays
-    if (document.getElementById('noarray').checked) {
+    if (noarray) {
       or = un;
     } else {
       or = un.sort();
@@ -51,25 +52,23 @@ function cleanJSON (input) {
   return input;
 }
 
-// Sort the JSON
-function sort (ev) {
-  var input, j, r;
+// Sort the JSON (clean, parse, sort, stringify).
+function sort (inputStr, noarray) {
+  var output, obj, r;
 
-  input = document.getElementById('t').value;
-
-  ev && ev.preventDefault();
-
-  if (input) {
+  if (inputStr) {
     try {
-      input = cleanJSON(input);
-      j = JSON.parse(input);
-      r = sortJSON(j);
-      document.getElementById('t').value = JSON.stringify(r, null, 4);
+      inputStr = cleanJSON(inputStr);
+      obj = JSON.parse(inputStr);
+      r = sortJSON(obj, noarray);
+      output = JSON.stringify(r, null, 4);
     } catch (ex) {
-      console.error('Incorrect JSON object');
-      window.alert('Incorrect JSON object');
+      console.error('jsonabc: Incorrect JSON object.', ex);
+      // Was: window.alert('Incorrect JSON object');
+      throw ex;
     }
   }
+  return output;
 }
 
 // End.

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 /*! JSON ABC Javascript.
 */
 
-// Start with a single exposed function.
-window.jsonabc = { sort: sort };
+module.exports = {
+  sort: sort,
+  sortObj: sortObj,
+  cleanJSON: cleanJSON
+};
 
 // Is a value an array
 function isArray (val) {
@@ -14,8 +17,10 @@ function isPlainObject (val) {
   return Object.prototype.toString.call(val) === '[object Object]';
 }
 
-// Sorting Logic
-function sortJSON (un, noarray) {
+// Sorting Logic (Was: 'sortJSON')
+function sortObj (un, noarray) {
+  noarray = noarray || false;
+
   var or = {};
 
   if (isArray(un)) {
@@ -27,7 +32,7 @@ function sortJSON (un, noarray) {
     }
 
     or.forEach(function (v, i) {
-      or[i] = sortJSON(v);
+      or[i] = sortObj(v);
     });
   } else if (isPlainObject(un)) {
     or = {};
@@ -36,7 +41,7 @@ function sortJSON (un, noarray) {
       if (a.toLowerCase() > b.toLowerCase()) return 1;
       return 0;
     }).forEach(function (key) {
-      or[key] = sortJSON(un[key]);
+      or[key] = sortObj(un[key]);
     });
   } else {
     or = un;
@@ -60,10 +65,10 @@ function sort (inputStr, noarray) {
     try {
       inputStr = cleanJSON(inputStr);
       obj = JSON.parse(inputStr);
-      r = sortJSON(obj, noarray);
+      r = sortObj(obj, noarray);
       output = JSON.stringify(r, null, 4);
     } catch (ex) {
-      console.error('jsonabc: Incorrect JSON object.', ex);
+      console.error('jsonabc: Incorrect JSON object.', [], ex);
       // Was: window.alert('Incorrect JSON object');
       throw ex;
     }

--- a/manifest.appcache
+++ b/manifest.appcache
@@ -1,5 +1,8 @@
 CACHE MANIFEST
-# 2018-03-01:v5
+# 2018-05-11:v2.x
 
 /favicon.ico
 index.html
+dist/jsonabc.js
+src/app.js
+style/app.css

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "jsonabc",
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Sorts JSON object alphabetically. It supports nested objects, arrays and collections. Works offline and beautifies JSON object too.",
+  "author": "Shivraj Rath",
+  "homepage": "http://novicelab.org/jsonabc",
+  "repository": "https://github.com/ShivrajRath/jsonabc",
+  "main": "index.js",
+  "devDependencies": {},
+  "keywords": [ "sorting", "beautify", "alphabet" ]
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,27 @@
 {
   "private": true,
   "name": "jsonabc",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "description": "Sorts JSON object alphabetically. It supports nested objects, arrays and collections. Works offline and beautifies JSON object too.",
-  "author": "Shivraj Rath",
   "homepage": "http://novicelab.org/jsonabc",
   "repository": "https://github.com/ShivrajRath/jsonabc",
+  "bugs": "",
   "main": "index.js",
-  "devDependencies": {},
-  "keywords": [ "sorting", "beautify", "alphabet" ]
+  "author": "Shivraj Rath",
+  "contributors": [
+    "Nick Freear"
+  ],
+  "devDependencies": {
+    "semistandard": "^12.0.1"
+  },
+  "scripts": {
+    "test": "semistandard",
+    "fix": "semistandard --fix"
+  },
+  "keywords": [
+    "sorting",
+    "beautify",
+    "alphabet"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,18 +4,21 @@
   "version": "2.0.0",
   "license": "MIT",
   "description": "Sorts JSON object alphabetically. It supports nested objects, arrays and collections. Works offline and beautifies JSON object too.",
+  "browser": "dist/jsonabc.js",
+  "main": "index.js",
   "homepage": "http://novicelab.org/jsonabc",
   "repository": "https://github.com/ShivrajRath/jsonabc",
-  "bugs": "",
-  "main": "index.js",
+  "bugs": "https://github.com/ShivrajRath/jsonabc/issues",
   "author": "Shivraj Rath",
   "contributors": [
     "Nick Freear"
   ],
   "devDependencies": {
+    "browserify": "^16.2.2",
     "semistandard": "^12.0.1"
   },
   "scripts": {
+    "build": "browserify -r ./index.js:jsonabc -o dist/jsonabc.js",
     "test": "semistandard",
     "fix": "semistandard --fix"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "semistandard": "^12.0.1"
   },
   "scripts": {
-    "build": "browserify -r ./index.js:jsonabc -o dist/jsonabc.js",
+    "build": "browserify --no-bf -r ./index.js:jsonabc -o dist/jsonabc.js",
     "test": "semistandard",
     "fix": "semistandard --fix"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,16 @@
+
+
+(function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r;
+    i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+    }, i[r].l = 1 * new Date();
+    a = s.createElement(o),
+    m = s.getElementsByTagName(o)[0];
+    a.async = 1;
+    a.src = g;
+    m.parentNode.insertBefore(a, m)
+})(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+ga('create', 'UA-58536835-1', 'auto');
+ga('send', 'pageview');

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,25 @@
+/*!
+  Form / application "onsubmit" handler, and analytics.
+*/
+
+window.appSort = appSort;
+
+function appSort (ev) {
+  var inputStr = document.getElementById('t').value;
+  var noarray = document.getElementById('noarray').checked;
+
+  ev && ev.preventDefault();
+
+  try {
+    var output = window.jsonabc.sort(inputStr, noarray);
+
+    document.getElementById('t').value = output;
+
+    console.warn('jsonabc input:', JSON.parse(inputStr));
+  } catch (ex) {
+    window.alert('Incorrect JSON object');
+  }
+}
 
 /* eslint-disable */
 (function (i, s, o, g, r, a, m) {

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 
-
+/* eslint-disable */
 (function (i, s, o, g, r, a, m) {
     i['GoogleAnalyticsObject'] = r;
     i[r] = i[r] || function () {
@@ -14,3 +14,4 @@
 
 ga('create', 'UA-58536835-1', 'auto');
 ga('send', 'pageview');
+/* eslint-enable */

--- a/src/app.js
+++ b/src/app.js
@@ -2,20 +2,22 @@
   Form / application "onsubmit" handler, and analytics.
 */
 
+var jsonabc = require('jsonabc');
+
 window.appSort = appSort;
 
-function appSort (ev) {
-  var inputStr = document.getElementById('t').value;
+function appSort (ev, tid) {
+  var inputStr = document.getElementById(tid).value;
   var noarray = document.getElementById('noarray').checked;
 
-  ev && ev.preventDefault();
+  ev.preventDefault();
 
   try {
-    var output = window.jsonabc.sort(inputStr, noarray);
+    var output = jsonabc.sort(inputStr, noarray);
 
-    document.getElementById('t').value = output;
+    document.getElementById(tid).value = output;
 
-    console.warn('jsonabc input:', JSON.parse(inputStr));
+    console.warn('jsonabc input:', JSON.parse(inputStr), noarray);
   } catch (ex) {
     window.alert('Incorrect JSON object');
   }

--- a/style/app.css
+++ b/style/app.css
@@ -38,6 +38,10 @@ span > * {
     display: inline-block;
 }
 
+form {
+  display: inline;
+}
+
 .ad {
     float: right;
 }
@@ -56,7 +60,7 @@ span > * {
 .m .t:active {
     width: 95%;
     height: 85%;
-    min-height: 250px;
+    /* min-height: 250px; */
     padding: 2%;
     resize: none;
     outline: none;

--- a/style/app.css
+++ b/style/app.css
@@ -1,0 +1,155 @@
+
+* {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    vertical-align: baseline;
+    font-family: 'Palatino', 'Calibri', sans-serif;
+}
+
+html,
+body {
+    height: 100%;
+    overflow: hidden;
+}
+
+body {
+    margin: 2% 5%;
+    line-height: 25px;
+}
+
+h2 {
+    color: #e6a117;
+}
+
+em {
+    font-weight: normal;
+}
+
+a {
+    color: #000;
+    text-decoration: none;
+    border-bottom: 1px solid #000;
+    padding-bottom: 3px;
+    cursor: pointer;
+}
+
+span > * {
+    display: inline-block;
+}
+
+.ad {
+    float: right;
+}
+
+.h {
+    font-size: 0.9em;
+    padding: 1% 0;
+}
+
+.m {
+    height: 65%;
+}
+
+.m .t,
+.m .t:focus,
+.m .t:active {
+    width: 95%;
+    height: 85%;
+    padding: 2%;
+    resize: none;
+    outline: none;
+    font-size: 1em;
+    text-decoration: none;
+    border: 1px solid #e6a117;
+    font-family: "Courier New", Courier, monospace;
+}
+
+.m .f {
+    font-size: 1em;
+    margin: 0 auto;
+    display: block;
+    cursor: pointer;
+    background: none;
+    padding: 1.5% 4% 1% 4%;
+    border: 1px solid #e6a117;
+}
+
+.b {
+    color: #e6a117;
+}
+
+.c {
+    text-align: center;
+    padding-top: 2%;
+}
+
+.mb10 {
+    margin-bottom: 10px;
+}
+
+@media only screen and (max-width: 768px) {
+    .ad {
+        display: none;
+    }
+    .m .t {
+        font-size: 0.5em;
+    }
+}
+
+@media only screen and (max-width: 420px) {
+    .ad {
+        display: none;
+
+    }
+    .m .t {
+        font-size: 0.3em;
+    }
+}
+
+/*
+  Buy me a coffee ~ https://buymeacoffee.com/
+*/
+
+.bmc-button img {
+    width: 27px !important;
+    margin-bottom: 3px !important;
+    box-shadow: none !important;
+    border: none !important;
+    vertical-align: middle !important;
+}
+
+.bmc-button {
+    line-height: 36px !important;
+    height: 37px !important;
+    text-decoration: none !important;
+    display: inline-block !important;
+    color: #FFFFFF !important;
+    background-color: #FF813F !important;
+    border-radius: 3px !important;
+    border: 1px solid transparent !important;
+    padding: 1px 9px !important;
+    font-size: 23px !important;
+    letter-spacing: 0.6px !important;
+    box-shadow: 0px 1px 2px rgba(190, 190, 190, 0.5) !important;
+    -webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
+    margin: 0 auto !important;
+    font-family: 'Cookie', cursive !important;
+    -webkit-box-sizing: border-box !important;
+    box-sizing: border-box !important;
+    -o-transition: 0.3s all linear !important;
+    -webkit-transition: 0.3s all linear !important;
+    -moz-transition: 0.3s all linear !important;
+    -ms-transition: 0.3s all linear !important;
+    transition: 0.3s all linear !important;
+}
+
+.bmc-button:hover,
+.bmc-button:active,
+.bmc-button:focus {
+    -webkit-box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
+    text-decoration: none !important;
+    box-shadow: 0px 1px 2px 2px rgba(190, 190, 190, 0.5) !important;
+    opacity: 0.85 !important;
+    color: #FFFFFF !important;
+}

--- a/style/app.css
+++ b/style/app.css
@@ -56,6 +56,7 @@ span > * {
 .m .t:active {
     width: 95%;
     height: 85%;
+    min-height: 250px;
     padding: 2%;
     resize: none;
     outline: none;


### PR DESCRIPTION
Hi @ShivrajRath,

I thought you may want to consider merging the changes that I've made to `jsonabc`.

The main change was to convert the sorting logic into a Node module, which can be:

 1. Used directly in Node:
    ```js
    var myJsonAbc = require('jsonabc');
    var sorted = myJsonAbc.sortObj({ c: 0, b: 1, a: 0 });
    ```
 2. Built by Browserify, for directly inclusion in the browser:
    ```html
    <script src="dist/jsonabc.js"></script>
    <script>
      var output = jsonabc.sort(inputStr, noarray);
    </script>
    ```

There also edits to add testing via Travis-CI, and to allow the package to be published to [NPMJS](https://npmjs.com) if you wish.

I hope this helps. Let me know if you have questions.

Best wishes,


Nick