### PR TITLE
Feature/preserve arb comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,24 +39,26 @@
 
     <form onsubmit="appSort(event, 't')">
 
-    <div class="o mb10">
-        <span>Options: &nbsp;&nbsp;</span>
-        <input type="checkbox" id="noarray" name="noarray" value="true">
-        <label for="noarray">Spare plain Arrays</label>
+        <div class="o mb10">
+            <span>Options: &nbsp;&nbsp;</span>
+            <input type="checkbox" id="noarray" name="noarray" value="true">
+            <label for="noarray">Spare plain Arrays</label>
             &nbsp;&nbsp;<input type="checkbox" id="useTabs" name="useTabs" value="true">
             <label for="useTabs">Use Tabs for indentation</label>
-    </div>
-    <div class="m">
-        <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here"
-          aria-label="Paste your unsorted JSON here" spellcheck="false" required aria-required="true"></textarea>
-        <input type="submit" class="f" value="SORT ABC" data-Was-onclick="sort()">
-        <p>
+            &nbsp;&nbsp;<input type="checkbox" id="arbComments" name="arbComments" value="true">
+            <label for="arbComments">Sort ARB file - Keep @comments ordered</label>            
+        </div>
+        <div class="m">
+            <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here"
+                aria-label="Paste your unsorted JSON here" spellcheck="false" required aria-required="true"></textarea>
+            <input type="submit" class="f" value="SORT ABC" data-Was-onclick="sort()">
+            <p>
             <h3 class="c">
                 <a href="https://github.com/ShivrajRath/jsonabc" target="_blank">Github</a>&nbsp;&nbsp;&nbsp;
                 <a href="https://novicelab.org/jsonsortdiff" target="_blank">JSON abc and diff</a>&nbsp;&nbsp;&nbsp;
             </h3>
-        </p>
-    </div>
+            </p>
+        </div>
 
     </form>
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
         <span>Options: &nbsp;&nbsp;</span>
         <input type="checkbox" id="noarray" name="noarray" value="true">
         <label for="noarray">Spare plain Arrays</label>
+            &nbsp;&nbsp;<input type="checkbox" id="useTabs" name="useTabs" value="true">
+            <label for="useTabs">Use Tabs for indentation</label>
     </div>
     <div class="m">
         <textarea id="t" class="t" name="jsonabc" placeholder="Paste your unsorted JSON here"

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function isPlainObject (val) {
 // Sorting Logic
 function sortObj (un, noarray) {
   noarray = noarray || false;
-
+  
   var or = {};
 
   if (isArray(un)) {

--- a/index.js
+++ b/index.js
@@ -9,19 +9,20 @@ module.exports = {
 };
 
 // Is a value an array?
-function isArray (val) {
+function isArray(val) {
   return Object.prototype.toString.call(val) === '[object Array]';
 }
 
 // Is a value an Object?
-function isPlainObject (val) {
+function isPlainObject(val) {
   return Object.prototype.toString.call(val) === '[object Object]';
 }
 
 // Sorting Logic
-function sortObj (un, noarray) {
+function sortObj(un, noarray, arbComments) {
   noarray = noarray || false;
-  
+  arbComments = arbComments || false;
+
   var or = {};
 
   if (isArray(un)) {
@@ -33,7 +34,7 @@ function sortObj (un, noarray) {
     }
 
     or.forEach(function (v, i) {
-      or[i] = sortObj(v, noarray);
+      or[i] = sortObj(v, noarray, arbComments);
     });
 
     if (!noarray) {
@@ -46,11 +47,15 @@ function sortObj (un, noarray) {
   } else if (isPlainObject(un)) {
     or = {};
     Object.keys(un).sort(function (a, b) {
+      if (arbComments) {
+        if (a.startsWith("@")) a = a.substring(1);
+        if (b.startsWith("@")) b = b.substring(1);
+      }
       if (a.toLowerCase() < b.toLowerCase()) return -1;
       if (a.toLowerCase() > b.toLowerCase()) return 1;
       return 0;
     }).forEach(function (key) {
-      or[key] = sortObj(un[key], noarray);
+      or[key] = sortObj(un[key], noarray, arbComments);
     });
   } else {
     or = un;
@@ -60,21 +65,21 @@ function sortObj (un, noarray) {
 }
 
 // Remove trailing commas
-function cleanJSON (input) {
+function cleanJSON(input) {
   input = input.replace(/,[ \t\r\n]+}/g, '}');
   input = input.replace(/,[ \t\r\n]+\]/g, ']');
   return input;
 }
 
 // Sort the JSON (clean, parse, sort, stringify).
-function sort (inputStr, noarray, space = 4) {
+function sort(inputStr, noarray, space = 4, arbComments) {
   var output, obj, r;
 
   if (inputStr) {
     try {
       inputStr = cleanJSON(inputStr);
       obj = JSON.parse(inputStr);
-      r = sortObj(obj, noarray);
+      r = sortObj(obj, noarray, arbComments);
       output = JSON.stringify(r, null, space);
     } catch (ex) {
       console.error('jsonabc: Incorrect JSON object.', [], ex);

--- a/src/app.js
+++ b/src/app.js
@@ -11,11 +11,12 @@ function appSort(ev, tid) {
   var noarray = document.getElementById('noarray').checked;
   var useTabs = document.getElementById('useTabs').checked;
   var spacer = useTabs ? '\t' : 4;
+  var arbComments = document.getElementById('arbComments').checked;
 
   ev.preventDefault();
 
   try {
-    var output = jsonabc.sort(inputStr, noarray, spacer);
+    var output = jsonabc.sort(inputStr, noarray, spacer, arbComments);
 
     document.getElementById(tid).value = output;
 

--- a/src/app.js
+++ b/src/app.js
@@ -6,14 +6,16 @@ var jsonabc = require('jsonabc');
 
 window.appSort = appSort;
 
-function appSort (ev, tid) {
+function appSort(ev, tid) {
   var inputStr = document.getElementById(tid).value;
   var noarray = document.getElementById('noarray').checked;
+  var useTabs = document.getElementById('useTabs').checked;
+  var spacer = useTabs ? '\t' : 4;
 
   ev.preventDefault();
 
   try {
-    var output = jsonabc.sort(inputStr, noarray);
+    var output = jsonabc.sort(inputStr, noarray, spacer);
 
     document.getElementById(tid).value = output;
 


### PR DESCRIPTION
In Flutter there are translations in `arb` files, which are mostly JSON files. But for comments, the keys starts with "@" at symbol, so this new option preserves the comments at the correct position. Example:

```
{
    "@common_dialog": "Common dialogs comments goes below",
    "common_dialogConfirmation_title": "Confirmation",
    "common_dialogConfirmation_yesButton_text": "Yes",
    "@common_label": "This is a comment, because it starts with @ at symbol",
    "common_label_back": "Back",
    "common_label_cancel": "Cancel",
    "common_label_close": "Close"
}

```